### PR TITLE
Update retrieving file raw url in gitlab

### DIFF
--- a/gitdir.js
+++ b/gitdir.js
@@ -112,7 +112,7 @@ function getFileDataPF(filesInfo) {
 
 
 function generateGitLabDownloadURL(fileinfo, options) {
-   return `${options.gitlab_API_root}/projects/${options.repo}/repository/files/${fileinfo.path}/raw?private_token=${options.private_token}&ref=${options.branch}`;
+   return `${options.gitlab_API_root}/projects/${options.repo}/repository/blobs/${fileinfo.id}/raw?private_token=${options.private_token}&ref=${options.branch}`;
 }
 
 /**


### PR DESCRIPTION
uses the standard retrieving method (`blob\:sha`) instead of `files/path` one. in that way, the lib can still access to file raws of files found in subfolders/directories of the gitlab repo using the file id/sha checksum of the file.